### PR TITLE
Update calibration_files.git url for https public access

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "calibration_files"]
 	path = calibration_files
-	url = git@github.com:fusionportable/calibration_files.git
+	url = https://github.com/fusionportable/calibration_files.git


### PR DESCRIPTION
If no GitHub SSH keys are set, there may exist some access problems to clone this repo using `git clone https://github.com/fusionportable/fusionportable_dataset_tools.git --recursive`.
Changing the submodule's URL may help resolve this.